### PR TITLE
Keep newlines from original

### DIFF
--- a/testdata/template-template.pretty
+++ b/testdata/template-template.pretty
@@ -1,5 +1,6 @@
 {{template "head.tmpl" .}}
 
 {{template "header.tmpl" .}}
+
 <hgroup>
 </hgroup>


### PR DESCRIPTION
Authors are very capable of placing newlines in templates. Keep these around in the formatted output.