### PR TITLE
Preserve content inside style/script tags since gotmplfmt is not a JS/CSS formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,63 @@ best left to something like Prettier.
 1. `go build`
 2. `./gotmplfmt < template.go.tmpl`
 
-# Before
+### Before
 
 ![Before fmt](Before.png)
 
-# After
+### After
 
 ![After fmt](After.png)
+
+## Neovim Configuration
+
+If using LazyVim, add the following to `lua/plugins/formatter.lua` and `lua/config/options.lua`:
+
+```lua
+-- lua/plugins/formatter.lua
+return {
+  "stevearc/conform.nvim",
+  opts = {
+    formatters = {
+      gotmplfmt = {
+        command = "gotmplfmt",
+      },
+    },
+    formatters_by_ft = {
+      gotmpl = { "gotmplfmt" },
+    },
+  },
+}
+
+-- lua/config/options.lua
+vim.filetype.add({
+  extension = {
+    gotmpl = "gotmpl",
+  },
+})
+
+-- If don't want `gopls` to highlight over `treesitter` highlights,
+-- add the following to `lua/config/lsp.lua`:
+
+return {
+  "neovim/nvim-lspconfig",
+  opts = {
+    servers = {
+      gopls = {
+        filetypes = { "go", "gomod", "gowork" }, # omit gotmpl
+      },
+    },
+  },
+}
+```
+
+## Tree-Sitter Injection Query
+
+Add also to `$HOME/.config/nvim/queries/gotmpl/injections.scm` the following
+to highlight the template content as HTML and not from `gopls`:
+
+```
+((text) @injection.content
+ (#set! injection.language "html")
+ (#set! injection.combined))
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gotmplfmt
 
-Fmt Go HTML templates.
+Format Go HTML templates (\*.gotmpl).
 
 Gotmplfmt only has one option (setting the width). The indenting used is 1 tab - this allow your editor's tab
 setting to do its work. The formatter is rather simple, there is no AST creation, it just iterates over a list
@@ -32,6 +32,12 @@ instead of:
 ```
 
 where the second `<body>` would indent the template even further.
+
+`<style>` and `<script>` tag contents are not formatted, as they are usually
+not HTML but CSS and JavaScript respectively.
+
+This is to prevent the formatter from breaking the CSS and JavaScript code and
+best left to something like Prettier.
 
 ## Usage
 

--- a/dumb.go
+++ b/dumb.go
@@ -35,6 +35,11 @@ func PrettyDumb(w io.Writer, tokens []Token) {
 		if level < 0 {
 			level = 0
 		}
+		// RawText (inside style/script tags) should be written as-is to preserve formatting
+		if token.Subtype == RawText {
+			fmt.Fprintf(w, "%s", token.Value)
+			continue
+		}
 		printIndent(w, level)
 		// embedded text with newline, like long comments need special treatment, to get indenting of each line
 		// correct. Can only be done here, because we have the indent level handy.

--- a/lex.go
+++ b/lex.go
@@ -85,6 +85,8 @@ func TokenIndent(s TokenSubtype) int {
 		return IndentNewlineKeep
 	case Comment:
 		return IndentNewlineKeep
+	case RawTagClose:
+		return IndentKeep
 	}
 	return IndentKeep
 }
@@ -109,6 +111,8 @@ const (
 	TagClose
 	TagNoop
 	Comment
+	RawText     // Text inside style/script tags that should not be reformatted
+	RawTagClose // Closing tag for style/script
 )
 
 var Subtypes = map[string]TokenSubtype{
@@ -127,11 +131,13 @@ var Subtypes = map[string]TokenSubtype{
 
 // Lexer holds the state of the lexer.
 type Lexer struct {
-	input  string
-	start  int
-	pos    int
-	width  int
-	tokens []Token
+	input      string
+	start      int
+	pos        int
+	width      int
+	tokens     []Token
+	inRawTag   bool   // true when inside <style> or <script>
+	rawTagName string // name of the raw tag we're inside
 }
 
 // NewLexer creates a new lexer for the given input.
@@ -211,6 +217,13 @@ func (l *Lexer) emit(t TokenType) {
 	defer func() { l.start = l.pos }()
 
 	if t == TokenText || t == TokenHTML {
+		// If we're inside a raw tag (style/script), mark text as RawText and don't trim
+		if t == TokenText && l.inRawTag {
+			subtype = RawText
+			l.tokens = append(l.tokens, Token{Type: t, Value: value, Subtype: subtype})
+			return
+		}
+
 		// If the token start with spaces and when trimmed is empty, we skip this token.
 		if trimmed := strings.TrimLeftFunc(value, unicode.IsSpace); len(trimmed) == 0 {
 			return
@@ -237,13 +250,27 @@ func (l *Lexer) emit(t TokenType) {
 		if !isInLineTag(value) {
 			switch {
 			case strings.HasPrefix(value, "</"):
-				subtype = TagClose
+				// Check if we're closing a raw tag
+				tag := htmlTag(value)
+				if tag == l.rawTagName {
+					subtype = RawTagClose
+					l.inRawTag = false
+					l.rawTagName = ""
+				} else {
+					subtype = TagClose
+				}
 			case strings.HasSuffix(value, "/>"):
 				// none
 			case strings.HasSuffix(value, ">") && isAutoCloseTag(value):
 				// none
 			case strings.HasPrefix(value, "<"):
 				subtype = TagOpen
+				// Check if we're opening a raw tag
+				tag := htmlTag(value)
+				if tag == "style" || tag == "script" {
+					l.inRawTag = true
+					l.rawTagName = tag
+				}
 			}
 			if isOpenOnceTag(value) {
 				subtype = TagNoop

--- a/testdata/script.pretty
+++ b/testdata/script.pretty
@@ -1,5 +1,5 @@
 <script>
-function test() {
+		function test() {
             console.log("hello");
         }
 </script>

--- a/testdata/style.pretty
+++ b/testdata/style.pretty
@@ -1,5 +1,5 @@
 <style type="text/tailwindcss">
-@theme {
+		@theme {
             /* --- Colors --- */
             --color-primary: #11172b;
         }


### PR DESCRIPTION
#33 did not work so well so better left the formatting to another formatter, e.g. prettier.


